### PR TITLE
Feature/#123 온보딩 프로세스 퍼블리싱

### DIFF
--- a/apps/app/src/components/@common/ScreenLayout.tsx
+++ b/apps/app/src/components/@common/ScreenLayout.tsx
@@ -17,7 +17,7 @@ type ScreenLayoutProps = {
   isKeyboardAvoiding?: boolean;
   isSafeArea?: boolean;
   backgroundColor?: KeyOfPalette;
-  style?: StyleProp<ViewStyle>
+  style?: StyleProp<ViewStyle>;
 };
 
 function ScreenLayout({
@@ -33,7 +33,7 @@ function ScreenLayout({
   const content = (
     <ViewComponent
       style={[
-        screenLayoutStyle.view,
+        screenLayoutStyle.base,
         {backgroundColor: theme.palette[backgroundColor]},
         style,
       ]}>
@@ -57,8 +57,11 @@ function ScreenLayout({
 export default ScreenLayout;
 
 const screenLayoutStyle = StyleSheet.create({
-  view: {
+  base: {
     flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    paddingVertical: 15,
   },
   keyboardAvoidingView: {
     flex: 1,

--- a/apps/app/src/screens/Onboarding/ChooseAnswerScreen.tsx
+++ b/apps/app/src/screens/Onboarding/ChooseAnswerScreen.tsx
@@ -1,5 +1,6 @@
-import {Text, TouchableOpacity} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import ScreenLayout from '../../components/@common/ScreenLayout';
+import Button from '../../components/@common/Button';
 
 export type ChooseAnswerScreenProps = {
   onNext: () => void;
@@ -8,12 +9,23 @@ export type ChooseAnswerScreenProps = {
 function ChooseAnswerScreen({onNext}: ChooseAnswerScreenProps) {
   return (
     <ScreenLayout isSafeArea>
-      <Text>ChooseAnswer Screen</Text>
-      <TouchableOpacity onPress={onNext}>
-        <Text>다음</Text>
-      </TouchableOpacity>
+      <View style={chooseAnswerScreenStyle.content} />
+      <View style={chooseAnswerScreenStyle.bottomButtonContainer}>
+        <Button onPress={onNext}>다음</Button>
+      </View>
     </ScreenLayout>
   );
 }
 
 export default ChooseAnswerScreen;
+
+const chooseAnswerScreenStyle = StyleSheet.create({
+  content: {
+    flex: 1,
+  },
+  bottomButtonContainer: {
+    marginBottom: 20,
+    display: 'flex',
+    alignItems: 'center',
+  },
+});

--- a/apps/app/src/screens/Onboarding/LoginScreen.tsx
+++ b/apps/app/src/screens/Onboarding/LoginScreen.tsx
@@ -1,17 +1,38 @@
-import {Text, TouchableOpacity} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import ScreenLayout from '../../components/@common/ScreenLayout';
+import SocialLoginButton from '../../components/@common/SocialLoginButton';
 
 export type LoginScreenProps = {onNext: () => void};
 
 function LoginScreen({onNext}: LoginScreenProps) {
   return (
-    <ScreenLayout isSafeArea>
-      <Text>Login Screen</Text>
-      <TouchableOpacity onPress={onNext}>
-        <Text>다음</Text>
-      </TouchableOpacity>
+    <ScreenLayout isSafeArea style={loginScreenStyle.base}>
+      <View style={loginScreenStyle.logoContainer} />
+      <View style={loginScreenStyle.socialLoginButtonContainer}>
+        <SocialLoginButton variant={'kakao'} />
+        <SocialLoginButton variant={'apple'} />
+      </View>
     </ScreenLayout>
   );
 }
 
 export default LoginScreen;
+
+const loginScreenStyle = StyleSheet.create({
+  base: {
+    paddingVertical: 15,
+    display: 'flex',
+    alignItems: 'center',
+  },
+  logoContainer: {
+    flex: 1,
+    borderWidth: 1,
+    width: '100%',
+    marginBottom: 20,
+  },
+  socialLoginButtonContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+  },
+});

--- a/apps/app/src/screens/Onboarding/LoginScreen.tsx
+++ b/apps/app/src/screens/Onboarding/LoginScreen.tsx
@@ -6,7 +6,7 @@ export type LoginScreenProps = {onNext: () => void};
 
 function LoginScreen({onNext}: LoginScreenProps) {
   return (
-    <ScreenLayout isSafeArea style={loginScreenStyle.base}>
+    <ScreenLayout isSafeArea>
       <View style={loginScreenStyle.logoContainer} />
       <View style={loginScreenStyle.socialLoginButtonContainer}>
         <SocialLoginButton variant={'kakao'} />
@@ -19,11 +19,6 @@ function LoginScreen({onNext}: LoginScreenProps) {
 export default LoginScreen;
 
 const loginScreenStyle = StyleSheet.create({
-  base: {
-    paddingVertical: 15,
-    display: 'flex',
-    alignItems: 'center',
-  },
   logoContainer: {
     flex: 1,
     borderWidth: 1,

--- a/apps/app/src/screens/Onboarding/SelectPhotoScreen.tsx
+++ b/apps/app/src/screens/Onboarding/SelectPhotoScreen.tsx
@@ -1,5 +1,6 @@
-import {Text, TouchableOpacity} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import ScreenLayout from '../../components/@common/ScreenLayout';
+import Button from '../../components/@common/Button';
 
 export type SelectPhotoScreenProps = {
   onNext: () => void;
@@ -8,12 +9,23 @@ export type SelectPhotoScreenProps = {
 function SelectPhotoScreen({onNext}: SelectPhotoScreenProps) {
   return (
     <ScreenLayout isSafeArea>
-      <Text>SelectPhoto Screen</Text>
-      <TouchableOpacity onPress={onNext}>
-        <Text>다음</Text>
-      </TouchableOpacity>
+      <View style={selectPhotoScreenStyle.content} />
+      <View style={selectPhotoScreenStyle.bottomButtonContainer}>
+        <Button onPress={onNext}>다음</Button>
+      </View>
     </ScreenLayout>
   );
 }
 
 export default SelectPhotoScreen;
+
+const selectPhotoScreenStyle = StyleSheet.create({
+  content: {
+    flex: 1,
+  },
+  bottomButtonContainer: {
+    marginBottom: 20,
+    display: 'flex',
+    alignItems: 'center',
+  },
+});

--- a/apps/app/src/screens/Onboarding/ShareOnSNSScreen.tsx
+++ b/apps/app/src/screens/Onboarding/ShareOnSNSScreen.tsx
@@ -1,17 +1,29 @@
-import {Text, TouchableOpacity} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import ScreenLayout from '../../components/@common/ScreenLayout';
+import Button from '../../components/@common/Button';
 
 export type ShareOnSNSScreenProps = {onNext: () => void};
 
 function ShareOnSNSScreen({onNext}: ShareOnSNSScreenProps) {
   return (
     <ScreenLayout isSafeArea>
-      <Text>ShareOnSNS Screen</Text>
-      <TouchableOpacity onPress={onNext}>
-        <Text>다음</Text>
-      </TouchableOpacity>
+      <View style={shareOnSNSScreenStyle.content} />
+      <View style={shareOnSNSScreenStyle.bottomButtonContainer}>
+        <Button onPress={onNext}>다음</Button>
+      </View>
     </ScreenLayout>
   );
 }
 
 export default ShareOnSNSScreen;
+
+const shareOnSNSScreenStyle = StyleSheet.create({
+  content: {
+    flex: 1,
+  },
+  bottomButtonContainer: {
+    marginBottom: 20,
+    display: 'flex',
+    alignItems: 'center',
+  },
+});

--- a/apps/app/src/screens/Onboarding/TermsAgreement/TermsAgreementScreen.tsx
+++ b/apps/app/src/screens/Onboarding/TermsAgreement/TermsAgreementScreen.tsx
@@ -82,7 +82,6 @@ const termsAgreementScreenStyle = StyleSheet.create({
     flex: 1,
   },
   bottomButtonContainer: {
-    padding: 15,
     marginBottom: 20,
     display: 'flex',
     alignItems: 'center',

--- a/apps/app/src/screens/Onboarding/ViewPastDiariesScreen.tsx
+++ b/apps/app/src/screens/Onboarding/ViewPastDiariesScreen.tsx
@@ -1,5 +1,6 @@
-import {Text, TouchableOpacity} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import ScreenLayout from '../../components/@common/ScreenLayout';
+import Button from '../../components/@common/Button';
 
 export type ViewPastDiariesScreenProps = {
   onNext: () => void;
@@ -8,12 +9,23 @@ export type ViewPastDiariesScreenProps = {
 function ViewPastDiariesScreen({onNext}: ViewPastDiariesScreenProps) {
   return (
     <ScreenLayout isSafeArea>
-      <Text>ViewPastDiaries Screen</Text>
-      <TouchableOpacity onPress={onNext}>
-        <Text>다음</Text>
-      </TouchableOpacity>
+      <View style={viewPastDiariesScreenStyle.content} />
+      <View style={viewPastDiariesScreenStyle.bottomButtonContainer}>
+        <Button onPress={onNext}>다음</Button>
+      </View>
     </ScreenLayout>
   );
 }
 
 export default ViewPastDiariesScreen;
+
+const viewPastDiariesScreenStyle = StyleSheet.create({
+  content: {
+    flex: 1,
+  },
+  bottomButtonContainer: {
+    marginBottom: 20,
+    display: 'flex',
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #123 