### PR TITLE
Feature/#128 토큰 관리를 위한 AsyncStorageService 및 훅 추가

### DIFF
--- a/apps/app/src/constants/asyncStorageKey.ts
+++ b/apps/app/src/constants/asyncStorageKey.ts
@@ -1,4 +1,4 @@
-const enum AsyncStorageKey {
+export const enum AsyncStorageKey {
   accessToken = 'accessToken',
   refreshToken = 'refreshToken',
 }

--- a/apps/app/src/constants/asyncStorageKey.ts
+++ b/apps/app/src/constants/asyncStorageKey.ts
@@ -1,0 +1,4 @@
+const enum AsyncStorageKey {
+  accessToken = 'accessToken',
+  refreshToken = 'refreshToken',
+}

--- a/apps/app/src/hooks/useAuthStorage.ts
+++ b/apps/app/src/hooks/useAuthStorage.ts
@@ -1,4 +1,5 @@
 import AsyncStorageService from '../utils/AsyncStorageService';
+import {AsyncStorageKey} from '../constants/asyncStorageKey';
 
 function useAuthStorage() {
   const setAuthData = async (accessToken: string, refreshToken: string) => {

--- a/apps/app/src/hooks/useAuthStorage.ts
+++ b/apps/app/src/hooks/useAuthStorage.ts
@@ -1,0 +1,42 @@
+import AsyncStorageService from '../utils/AsyncStorageService';
+
+function useAuthStorage() {
+  const setAuthData = async (accessToken: string, refreshToken: string) => {
+    await AsyncStorageService.multiSet([
+      {key: AsyncStorageKey.accessToken, value: accessToken},
+      {key: AsyncStorageKey.refreshToken, value: refreshToken},
+    ]);
+  };
+
+  const getAuthData = async () => {
+    return await AsyncStorageService.multiGet([
+      AsyncStorageKey.accessToken,
+      AsyncStorageKey.refreshToken,
+    ]);
+  };
+
+  const getAccessToken = async () => {
+    return await AsyncStorageService.getItem(AsyncStorageKey.accessToken);
+  };
+
+  const getRefreshToken = async () => {
+    return await AsyncStorageService.getItem(AsyncStorageKey.refreshToken);
+  };
+
+  const clearAuthData = async () => {
+    await AsyncStorageService.multiSet([
+      {key: AsyncStorageKey.accessToken, value: null},
+      {key: AsyncStorageKey.refreshToken, value: null},
+    ]);
+  };
+
+  return {
+    setAuthData,
+    getAuthData,
+    getAccessToken,
+    getRefreshToken,
+    clearAuthData,
+  };
+}
+
+export default useAuthStorage;

--- a/apps/app/src/screens/Onboarding/LoginScreen.tsx
+++ b/apps/app/src/screens/Onboarding/LoginScreen.tsx
@@ -5,10 +5,13 @@ import {
   loginWithKakaoAccount,
   getProfile,
 } from '@react-native-seoul/kakao-login';
+import useAuthStorage from '../../hooks/useAuthStorage';
 
 export type LoginScreenProps = {onNext: () => void};
 
 function LoginScreen({onNext}: LoginScreenProps) {
+  const {setAuthData} = useAuthStorage();
+
   const handlePressKakaoLoginButton = async () => {
     const {accessToken, refreshToken} = await loginWithKakaoAccount();
     const {
@@ -25,6 +28,11 @@ function LoginScreen({onNext}: LoginScreenProps) {
     };
 
     console.log(userData);
+
+    // TODO: API 연결
+
+    setAuthData(accessToken, refreshToken);
+    onNext();
   };
 
   const handlePressAppleLoginButton = () => {};

--- a/apps/app/src/utils/AsyncStorageService.ts
+++ b/apps/app/src/utils/AsyncStorageService.ts
@@ -14,6 +14,19 @@ class AsyncStorageService {
     }
   }
 
+  static async multiSet<T>(
+    keyValuePairs: {key: KeyOfAsyncStorageService; value: T}[],
+  ): Promise<void> {
+    try {
+      const formattedPairs: [string, string][] = keyValuePairs.map(
+        ({key, value}) => [key, JSON.stringify(value)],
+      );
+      await AsyncStorage.multiSet(formattedPairs);
+    } catch (error) {
+      console.error(`Error saving multiple data: `, error);
+    }
+  }
+
   static async getItem<T>(key: KeyOfAsyncStorageService): Promise<T | null> {
     try {
       const value = await AsyncStorage.getItem(key);
@@ -21,6 +34,22 @@ class AsyncStorageService {
     } catch (error) {
       console.log(`Error loading data [${key}]: `, error);
       return null;
+    }
+  }
+
+  static async multiGet<T>(
+    keys: KeyOfAsyncStorageService[],
+  ): Promise<Record<string, T | null>> {
+    try {
+      const values = await AsyncStorage.multiGet(keys);
+
+      return values.reduce((acc, [key, value]) => {
+        acc[key] = value ? JSON.parse(value) : null;
+        return acc;
+      }, {} as Record<string, T | null>);
+    } catch (error) {
+      console.error(`Error loading multiple data: `, error);
+      return {};
     }
   }
 

--- a/apps/app/src/utils/AsyncStorageService.ts
+++ b/apps/app/src/utils/AsyncStorageService.ts
@@ -1,12 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-type KeyOfAsyncStorageService = 'accessToken';
-
 class AsyncStorageService {
-  static async setItem<T>(
-    key: KeyOfAsyncStorageService,
-    value: T,
-  ): Promise<void> {
+  static async setItem<T>(key: AsyncStorageKey, value: T): Promise<void> {
     try {
       await AsyncStorage.setItem(key, JSON.stringify(value));
     } catch (error) {
@@ -15,7 +10,7 @@ class AsyncStorageService {
   }
 
   static async multiSet<T>(
-    keyValuePairs: {key: KeyOfAsyncStorageService; value: T}[],
+    keyValuePairs: {key: AsyncStorageKey; value: T}[],
   ): Promise<void> {
     try {
       const formattedPairs: [string, string][] = keyValuePairs.map(
@@ -27,7 +22,7 @@ class AsyncStorageService {
     }
   }
 
-  static async getItem<T>(key: KeyOfAsyncStorageService): Promise<T | null> {
+  static async getItem<T>(key: AsyncStorageKey): Promise<T | null> {
     try {
       const value = await AsyncStorage.getItem(key);
       return value !== null ? JSON.parse(value) : null;
@@ -38,7 +33,7 @@ class AsyncStorageService {
   }
 
   static async multiGet<T>(
-    keys: KeyOfAsyncStorageService[],
+    keys: AsyncStorageKey[],
   ): Promise<Record<string, T | null>> {
     try {
       const values = await AsyncStorage.multiGet(keys);
@@ -53,7 +48,7 @@ class AsyncStorageService {
     }
   }
 
-  static async removeItem(key: KeyOfAsyncStorageService): Promise<void> {
+  static async removeItem(key: AsyncStorageKey): Promise<void> {
     try {
       await AsyncStorage.removeItem(key);
     } catch (error) {

--- a/apps/app/src/utils/AsyncStorageService.ts
+++ b/apps/app/src/utils/AsyncStorageService.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {AsyncStorageKey} from '../constants/asyncStorageKey';
 
 class AsyncStorageService {
   static async setItem<T>(key: AsyncStorageKey, value: T): Promise<void> {

--- a/apps/app/src/utils/AsyncStorageService.ts
+++ b/apps/app/src/utils/AsyncStorageService.ts
@@ -1,0 +1,44 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+type KeyOfAsyncStorageService = 'accessToken';
+
+class AsyncStorageService {
+  static async setItem<T>(
+    key: KeyOfAsyncStorageService,
+    value: T,
+  ): Promise<void> {
+    try {
+      await AsyncStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.log(`Error saving data [${key}]: `, error);
+    }
+  }
+
+  static async getItem<T>(key: KeyOfAsyncStorageService): Promise<T | null> {
+    try {
+      const value = await AsyncStorage.getItem(key);
+      return value !== null ? JSON.parse(value) : null;
+    } catch (error) {
+      console.log(`Error loading data [${key}]: `, error);
+      return null;
+    }
+  }
+
+  static async removeItem(key: KeyOfAsyncStorageService): Promise<void> {
+    try {
+      await AsyncStorage.removeItem(key);
+    } catch (error) {
+      console.log(`Error removing data [${key}]: `, error);
+    }
+  }
+
+  static async clear(): Promise<void> {
+    try {
+      await AsyncStorage.clear();
+    } catch (error) {
+      console.log(`Error clearing AsyncStorage: `, error);
+    }
+  }
+}
+
+export default AsyncStorageService;


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #131 
- resolved #132 