### PR TITLE
Feature/#136 바텀시트 컴포넌트 구현

### DIFF
--- a/apps/app/ios/greeenai.xcodeproj/project.pbxproj
+++ b/apps/app/ios/greeenai.xcodeproj/project.pbxproj
@@ -643,7 +643,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -717,7 +720,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -16,6 +16,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@gorhom/bottom-sheet": "^5.1.1",
     "@greeenai/design-tokens": "workspace:^",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-seoul/kakao-login": "^5.4.1",

--- a/apps/app/src/components/@common/BottomSheet/BottomSheet.stories.tsx
+++ b/apps/app/src/components/@common/BottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,38 @@
+import {useRef} from 'react';
+import {Text, TouchableOpacity, View} from 'react-native';
+import BottomSheet from '.';
+import {BottomSheetModal} from '@gorhom/bottom-sheet';
+
+export default {
+  title: 'UI/BottomSheet',
+  component: BottomSheet,
+  tags: ['autodocs'],
+};
+
+export const Default = () => {
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+
+  const handlePressOpenBottomSheet = () => {
+    bottomSheetRef.current?.present();
+  };
+
+  const handlePressCloseBottomSheet = () => {
+    bottomSheetRef.current?.dismiss();
+  };
+
+  return (
+    <View style={{flex: 1, padding: 24}}>
+      <TouchableOpacity onPress={handlePressOpenBottomSheet}>
+        <Text>바텀시트 열기</Text>
+      </TouchableOpacity>
+      <BottomSheet ref={bottomSheetRef} snapPoints={['50%']}>
+        <View style={{flex: 1, padding: 24}}>
+          <Text>바텀시트 내용</Text>
+          <TouchableOpacity onPress={handlePressCloseBottomSheet}>
+            <Text>바텀시트 닫기</Text>
+          </TouchableOpacity>
+        </View>
+      </BottomSheet>
+    </View>
+  );
+};

--- a/apps/app/src/components/@common/BottomSheet/index.tsx
+++ b/apps/app/src/components/@common/BottomSheet/index.tsx
@@ -1,0 +1,64 @@
+import {
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+  BottomSheetModal,
+  BottomSheetModalProps,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet';
+import {forwardRef, ReactNode, Ref, useImperativeHandle, useRef} from 'react';
+import {StyleProp, ViewStyle} from 'react-native';
+
+type BottomSheetRef = {
+  present: () => void;
+  dismiss: () => void;
+};
+
+type BottomSheetProps = BottomSheetModalProps & {
+  children: ReactNode;
+  backdropOpacity?: number;
+  enableBackdropDismiss?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+function BottomSheet(
+  {
+    children,
+    backdropOpacity = 0.7,
+    enableBackdropDismiss = true,
+    ...rest
+  }: BottomSheetProps,
+  ref: Ref<BottomSheetRef>,
+) {
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+
+  useImperativeHandle(ref, () => ({
+    present: () => bottomSheetRef.current?.present(),
+    dismiss: () => bottomSheetRef.current?.dismiss(),
+  }));
+
+  const renderBackdrop = (
+    props: BottomSheetBackdropProps & {
+      backdropOpacity?: number;
+      enableBackdropDismiss?: boolean;
+    },
+  ) => (
+    <BottomSheetBackdrop
+      {...props}
+      disappearsOnIndex={-1}
+      appearsOnIndex={0}
+      opacity={backdropOpacity}
+      pressBehavior={enableBackdropDismiss ? 'close' : 'none'}
+    />
+  );
+
+  return (
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      backdropComponent={renderBackdrop}
+      {...rest}>
+      <BottomSheetView>{children}</BottomSheetView>
+    </BottomSheetModal>
+  );
+}
+
+export default forwardRef<BottomSheetRef, BottomSheetProps>(BottomSheet);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   apps/app:
     dependencies:
+      '@gorhom/bottom-sheet':
+        specifier: ^5.1.1
+        version: 5.1.1(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1)
       '@greeenai/design-tokens':
         specifier: workspace:^
         version: link:../../packages/design-tokens
@@ -143,13 +146,13 @@ importers:
         version: 8.4.3(prettier@2.8.8)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)
       '@storybook/addon-ondevice-controls':
         specifier: ^8.3.5
-        version: 8.4.3(@gorhom/bottom-sheet@4.6.4)(@react-native-community/datetimepicker@8.2.0)(@react-native-community/slider@4.5.5)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
+        version: 8.4.3(@gorhom/bottom-sheet@5.1.1)(@react-native-community/datetimepicker@8.2.0)(@react-native-community/slider@4.5.5)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
       '@storybook/react':
         specifier: ^8.4.7
         version: 8.4.7(react-dom@18.3.1)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
       '@storybook/react-native':
         specifier: ^8.3.5
-        version: 8.4.3(@gorhom/bottom-sheet@4.6.4)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(typescript@5.5.4)
+        version: 8.4.3(@gorhom/bottom-sheet@5.1.1)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(typescript@5.5.4)
       '@types/react-native':
         specifier: ^0.73.0
         version: 0.73.0(@babel/core@7.26.0)(@babel/preset-env@7.26.0)(@types/react@19.0.1)(react@18.3.1)(typescript@5.5.4)
@@ -2186,15 +2189,15 @@ packages:
       levn: 0.4.1
     dev: true
 
-  /@gorhom/bottom-sheet@4.6.4(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1):
-    resolution: {integrity: sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==}
+  /@gorhom/bottom-sheet@5.1.1(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1):
+    resolution: {integrity: sha512-Y8FiuRmeZYaP+ZGQ0axDwWrrKqVp4ByYRs1D2fTJTxHMt081MHHRQsqmZ3SK7AFp3cSID+vTqnD8w/KAASpy+w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-native': '*'
       react: '*'
       react-native: '*'
-      react-native-gesture-handler: '>=1.10.1'
-      react-native-reanimated: '>=2.2.0'
+      react-native-gesture-handler: '>=2.16.1'
+      react-native-reanimated: '>=3.16.0'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2209,7 +2212,6 @@ packages:
       react-native: 0.75.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0)(@types/react@19.0.1)(react@18.3.1)(typescript@5.5.4)
       react-native-gesture-handler: 2.21.2(react-native@0.75.3)(react@18.3.1)
       react-native-reanimated: 3.16.7(@babel/core@7.26.0)(react-native@0.75.3)(react@18.3.1)
-    dev: true
 
   /@gorhom/portal@1.0.14(react-native@0.75.3)(react@18.3.1):
     resolution: {integrity: sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==}
@@ -2220,7 +2222,6 @@ packages:
       nanoid: 3.3.8
       react: 18.3.1
       react-native: 0.75.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0)(@types/react@19.0.1)(react@18.3.1)(typescript@5.5.4)
-    dev: true
 
   /@hapi/hoek@9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -3840,7 +3841,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@storybook/addon-ondevice-controls@8.4.3(@gorhom/bottom-sheet@4.6.4)(@react-native-community/datetimepicker@8.2.0)(@react-native-community/slider@4.5.5)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4):
+  /@storybook/addon-ondevice-controls@8.4.3(@gorhom/bottom-sheet@5.1.1)(@react-native-community/datetimepicker@8.2.0)(@react-native-community/slider@4.5.5)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4):
     resolution: {integrity: sha512-iVO+14HCdbpLYFpBcdUJ3+b1Oc9mo4R5/VdX/qEM91MN0euw29N4EY7n2ja+fv+cprx4q5TWIE1vyZXCVwLweA==}
     peerDependencies:
       '@gorhom/bottom-sheet': '>=4'
@@ -3849,13 +3850,13 @@ packages:
       react: '*'
       react-native: '*'
     dependencies:
-      '@gorhom/bottom-sheet': 4.6.4(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1)
+      '@gorhom/bottom-sheet': 5.1.1(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1)
       '@react-native-community/datetimepicker': 8.2.0(react-native@0.75.3)(react@18.3.1)
       '@react-native-community/slider': 4.5.5
       '@storybook/addon-controls': 8.4.7(storybook@8.4.7)
       '@storybook/core': 8.4.7(prettier@2.8.8)
       '@storybook/react-native-theming': 8.4.3(react-native@0.75.3)(react@18.3.1)
-      '@storybook/react-native-ui': 8.4.3(@gorhom/bottom-sheet@4.6.4)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
+      '@storybook/react-native-ui': 8.4.3(@gorhom/bottom-sheet@5.1.1)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
       deep-equal: 1.1.2
       prop-types: 15.8.1
       react: 18.3.1
@@ -4299,7 +4300,7 @@ packages:
       react-native: 0.75.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0)(@types/react@19.0.1)(react@18.3.1)(typescript@5.5.4)
     dev: true
 
-  /@storybook/react-native-ui@8.4.3(@gorhom/bottom-sheet@4.6.4)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4):
+  /@storybook/react-native-ui@8.4.3(@gorhom/bottom-sheet@5.1.1)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4):
     resolution: {integrity: sha512-FJZKVIKolUfWBSGllxaIA8h0iyrEwMqpE9dULORaCmTTo+L2GdPBDQG4UsaAjDuNh1M6TZ3WufUNenn2tem5rA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -4311,7 +4312,7 @@ packages:
       react-native-safe-area-context: '*'
       react-native-svg: '>=14'
     dependencies:
-      '@gorhom/bottom-sheet': 4.6.4(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1)
+      '@gorhom/bottom-sheet': 5.1.1(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1)
       '@storybook/core': 8.4.7(prettier@2.8.8)
       '@storybook/react': 8.4.7(react-dom@18.3.1)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
       '@storybook/react-native-theming': 8.4.3(react-native@0.75.3)(react@18.3.1)
@@ -4336,7 +4337,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@storybook/react-native@8.4.3(@gorhom/bottom-sheet@4.6.4)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(typescript@5.5.4):
+  /@storybook/react-native@8.4.3(@gorhom/bottom-sheet@5.1.1)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(typescript@5.5.4):
     resolution: {integrity: sha512-THO/Ynxh+ojiERrhbKr3vpd5POu7X3pFmU2khhuaY+BIXyQDenNyDwrri/PkUV1+PhE1t2UYkO44JUUcE9/pAw==}
     engines: {node: '>=8.0.0'}
     hasBin: true
@@ -4347,13 +4348,13 @@ packages:
       react-native-gesture-handler: '>=2'
       react-native-safe-area-context: '*'
     dependencies:
-      '@gorhom/bottom-sheet': 4.6.4(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1)
+      '@gorhom/bottom-sheet': 5.1.1(@types/react-native@0.73.0)(@types/react@19.0.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native@0.75.3)(react@18.3.1)
       '@storybook/core': 8.4.7(prettier@2.8.8)
       '@storybook/csf': 0.1.12
       '@storybook/global': 5.0.0
       '@storybook/react': 8.4.7(react-dom@18.3.1)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
       '@storybook/react-native-theming': 8.4.3(react-native@0.75.3)(react@18.3.1)
-      '@storybook/react-native-ui': 8.4.3(@gorhom/bottom-sheet@4.6.4)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
+      '@storybook/react-native-ui': 8.4.3(@gorhom/bottom-sheet@5.1.1)(prettier@2.8.8)(react-dom@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.7)(react-native-safe-area-context@4.14.1)(react-native-svg@15.11.1)(react-native@0.75.3)(react@18.3.1)(storybook@8.4.7)(typescript@5.5.4)
       chokidar: 3.6.0
       commander: 8.3.0
       dedent: 1.5.3
@@ -4813,7 +4814,6 @@ packages:
       - supports-color
       - typescript
       - utf-8-validate
-    dev: true
 
   /@types/react-test-renderer@18.3.1:
     resolution: {integrity: sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==}


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #136 