### PR TITLE
Feature/#169 일기 갤러리에 저장하기 기능 구현

### DIFF
--- a/apps/app/ios/Podfile.lock
+++ b/apps/app/ios/Podfile.lock
@@ -1254,6 +1254,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-cameraroll (7.10.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-config (1.5.5):
     - react-native-config/App (= 1.5.5)
   - react-native-config/App (1.5.5):
@@ -1522,6 +1543,8 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
+  - rn-fetch-blob (0.12.0):
+    - React-Core
   - RNCAsyncStorage (2.1.0):
     - React-Core
   - RNGestureHandler (2.21.2):
@@ -1700,6 +1723,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - "react-native-cameraroll (from `../node_modules/@react-native-camera-roll/camera-roll`)"
   - react-native-config (from `../node_modules/react-native-config`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
@@ -1729,6 +1753,7 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
@@ -1819,6 +1844,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-cameraroll:
+    :path: "../node_modules/@react-native-camera-roll/camera-roll"
   react-native-config:
     :path: "../node_modules/react-native-config"
   react-native-safe-area-context:
@@ -1877,6 +1904,8 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  rn-fetch-blob:
+    :path: "../node_modules/rn-fetch-blob"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNGestureHandler:
@@ -1933,6 +1962,7 @@ SPEC CHECKSUMS:
   React-logger: 4072f39df335ca443932e0ccece41fbeb5ca8404
   React-Mapbuffer: 714f2fae68edcabfc332b754e9fbaa8cfc68fdd4
   React-microtasksnativemodule: 4943ad8f99be8ccf5a63329fa7d269816609df9e
+  react-native-cameraroll: 9a1e0fcf731da9092595987466b903771f00387a
   react-native-config: 3367df9c1f25bb96197007ec531c7087ed4554c3
   react-native-safe-area-context: 141eca0fd4e4191288dfc8b96a7c7e1c2983447a
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
@@ -1962,6 +1992,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: ff95a93d5ab5d9b2551571886271478eaa168565
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
+  rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNCAsyncStorage: cc6479c4acd84cc7004946946c8afe30b018184d
   RNGestureHandler: aa9690789023c9be8f06aa90e10ce637ea788f4d
   RNPermissions: 43bbafd931a378f6f2783ccc87a819ed3c49bb96

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -36,7 +36,8 @@
     "react-native-screens": "^4.5.0",
     "react-native-splash-screen": "^3.3.0",
     "react-native-svg": "^15.7.1",
-    "react-native-svg-transformer": "^1.5.0"
+    "react-native-svg-transformer": "^1.5.0",
+    "rn-fetch-blob": "^0.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -19,6 +19,7 @@
     "@gorhom/bottom-sheet": "^5.1.1",
     "@greeenai/design-tokens": "workspace:^",
     "@react-native-async-storage/async-storage": "^2.1.0",
+    "@react-native-camera-roll/camera-roll": "^7.10.0",
     "@react-native-seoul/kakao-login": "^5.4.1",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",

--- a/apps/app/src/screens/BottomTab/PastDiary/DiaryContentScreen.tsx
+++ b/apps/app/src/screens/BottomTab/PastDiary/DiaryContentScreen.tsx
@@ -1,14 +1,16 @@
-import {Image, ScrollView, StyleSheet, View} from 'react-native';
-import ScreenLayout from '../../../components/@common/ScreenLayout';
+import {useLayoutEffect} from 'react';
+import {Alert, Image, ScrollView, StyleSheet, View} from 'react-native';
 import {SCREEN_WIDTH} from '@gorhom/bottom-sheet';
 import {useNavigation, useRoute, RouteProp} from '@react-navigation/native';
-import {useLayoutEffect} from 'react';
+import {CameraRoll} from '@react-native-camera-roll/camera-roll';
+import ScreenLayout from '../../../components/@common/ScreenLayout';
 import {PastDiaryStackNavigatorParamList} from '../../../types/navigators';
 import {formatDateToYYMMDD} from '../../../utils/formatDate';
 import {mockDiaryContent} from '../../../constants/mockDatas/diaryContent';
 import Typography from '../../../components/@common/Typography';
 import Button from '../../../components/@common/Button';
 import Icon from '../../../components/@common/Icon';
+import {downloadImageToLocal} from '../../../utils/downloadImageInLocal';
 
 function DiaryContentScreen() {
   const navigation = useNavigation();
@@ -20,6 +22,19 @@ function DiaryContentScreen() {
     /([.!?])\s*/g,
     '$1\n',
   );
+
+  const handlePressSaveDiaryImage = async () => {
+    try {
+      const imageUrl = mockDiaryContent.imageUrl;
+      const localImagePath = await downloadImageToLocal(imageUrl);
+
+      await CameraRoll.saveAsset(localImagePath, {type: 'photo'});
+      Alert.alert('저장 완료', '이미지가 갤러리에 저장되었습니다.');
+    } catch (error) {
+      console.error('이미지 저장 실패:', error);
+      Alert.alert('저장 실패', '이미지를 갤러리에 저장하는데 실패했습니다.');
+    }
+  };
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -44,7 +59,7 @@ function DiaryContentScreen() {
           <Button
             leftElement={<Icon name={'SaveInGallery'} width={20} height={20} />}
             size={'sm'}
-            onPress={() => {}}>
+            onPress={handlePressSaveDiaryImage}>
             저장하기
           </Button>
           <Button

--- a/apps/app/src/utils/downloadImageInLocal.ts
+++ b/apps/app/src/utils/downloadImageInLocal.ts
@@ -1,0 +1,27 @@
+import {Alert, Platform} from 'react-native';
+import RNFetchBlob from 'rn-fetch-blob';
+
+export const downloadImageToLocal = async (imageUrl: string) => {
+  try {
+    const {fs} = RNFetchBlob;
+    const documentDir = fs.dirs.DocumentDir;
+    const timestamp = new Date().getTime();
+    const imagePath = `${documentDir}/diary_${timestamp}.jpg`;
+
+    await RNFetchBlob.config({
+      fileCache: true,
+      path: imagePath,
+    }).fetch('GET', imageUrl);
+
+    const localImagePath =
+      Platform.OS === 'ios' ? `file://${imagePath}` : imagePath;
+
+    return localImagePath;
+  } catch (error) {
+    Alert.alert(
+      '이미지 다운로드 실패',
+      '이미지를 다운로드하는데 실패했습니다.',
+    );
+    return '';
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       react-native-svg-transformer:
         specifier: ^1.5.0
         version: 1.5.0(react-native-svg@15.11.1)(react-native@0.75.3)(typescript@5.5.4)
+      rn-fetch-blob:
+        specifier: ^0.12.0
+        version: 0.12.0
     devDependencies:
       '@babel/core':
         specifier: ^7.20.0
@@ -5931,6 +5934,10 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /base-64@0.1.0:
+    resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
+    dev: false
+
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -8106,6 +8113,18 @@ packages:
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
     dev: true
+
+  /glob@7.0.6:
+    resolution: {integrity: sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: false
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -11372,6 +11391,13 @@ packages:
       hash-base: 3.0.5
       inherits: 2.0.4
     dev: true
+
+  /rn-fetch-blob@0.12.0:
+    resolution: {integrity: sha512-+QnR7AsJ14zqpVVUbzbtAjq0iI8c9tCg49tIoKO2ezjzRunN7YL6zFSFSWZm6d+mE/l9r+OeDM3jmb2tBb2WbA==}
+    dependencies:
+      base-64: 0.1.0
+      glob: 7.0.6
+    dev: false
 
   /rollup@4.28.1:
     resolution: {integrity: sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: ^2.1.0
         version: 2.1.0(react-native@0.75.3)
+      '@react-native-camera-roll/camera-roll':
+        specifier: ^7.10.0
+        version: 7.10.0(react-native@0.75.3)
       '@react-native-seoul/kakao-login':
         specifier: ^5.4.1
         version: 5.4.1(react-native@0.75.3)(react@18.3.1)
@@ -2868,6 +2871,15 @@ packages:
       react-native: ^0.0.0-0 || >=0.65 <1.0
     dependencies:
       merge-options: 3.0.4
+      react-native: 0.75.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0)(@types/react@19.0.1)(react@18.3.1)(typescript@5.5.4)
+    dev: false
+
+  /@react-native-camera-roll/camera-roll@7.10.0(react-native@0.75.3):
+    resolution: {integrity: sha512-Zm1yHxxTQS2APsnnxUFoLnK+DMMTPqmIQ2z2pGtNyHRXAG40Nt4MLVB3tDJTWnuJLAG87BpTCEvpz49+u0YkUw==}
+    engines: {node: '>= 18.17.0'}
+    peerDependencies:
+      react-native: '>=0.59'
+    dependencies:
       react-native: 0.75.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0)(@types/react@19.0.1)(react@18.3.1)(typescript@5.5.4)
     dev: false
 


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #169 