### PR TITLE
Feature/#195 지난 일기 조회 api 연결

### DIFF
--- a/apps/app/.eslintrc.js
+++ b/apps/app/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
   extends: '@react-native',
   rules: {
     '@typescript-eslint/func-call-spacing': 'off',
+    'react/react-in-jsx-scope': 'off',
   },
 };

--- a/apps/app/src/apis/diary/index.ts
+++ b/apps/app/src/apis/diary/index.ts
@@ -1,0 +1,12 @@
+import {ApiResponse} from '../api';
+import {fetcherInstance} from '../fetcher';
+import {LastDiariesResponse} from './index.types';
+
+class DiaryApi {
+  static async getLastDiaries() {
+    const response = await fetcherInstance.get('/diaries');
+    return response as ApiResponse<LastDiariesResponse>;
+  }
+}
+
+export default DiaryApi;

--- a/apps/app/src/apis/diary/index.types.ts
+++ b/apps/app/src/apis/diary/index.types.ts
@@ -1,4 +1,6 @@
-export interface LastDiariesResponse {
+export type LastDiariesResponse = LastDiary[];
+
+export interface LastDiary {
   id: number;
   content: string;
   imageUrl: string;

--- a/apps/app/src/apis/diary/index.types.ts
+++ b/apps/app/src/apis/diary/index.types.ts
@@ -1,0 +1,6 @@
+export interface LastDiariesResponse {
+  id: number;
+  content: string;
+  imageUrl: string;
+  entryDate: string;
+}

--- a/apps/app/src/components/BottomTab/PastDiary/EmptyDiary.tsx
+++ b/apps/app/src/components/BottomTab/PastDiary/EmptyDiary.tsx
@@ -7,7 +7,7 @@ function EmptyDiary() {
   const {bottomTabNavigation} = useNavigator();
 
   const handlePressCreateDiary = () => {
-    bottomTabNavigation.navigate('CreateDiary');
+    bottomTabNavigation.navigate('CreateDiaryStackNavigator');
   };
 
   return (

--- a/apps/app/src/screens/BottomTab/PastDiary/DiaryContentScreen.tsx
+++ b/apps/app/src/screens/BottomTab/PastDiary/DiaryContentScreen.tsx
@@ -16,7 +16,6 @@ import {captureRef} from 'react-native-view-shot';
 import ScreenLayout from '../../../components/@common/ScreenLayout';
 import {PastDiaryStackNavigatorParamList} from '../../../types/navigators';
 import {formatDateToYYMMDD} from '../../../utils/formatDate';
-import {mockDiaryContent} from '../../../constants/mockDatas/diaryContent';
 import Typography from '../../../components/@common/Typography';
 import Button from '../../../components/@common/Button';
 import Icon from '../../../components/@common/Icon';
@@ -29,11 +28,8 @@ function DiaryContentScreen() {
   const scrollViewRef = useRef(null);
   const contentRef = useRef(null);
 
-  const createdAt = route.params.createdAt;
-  const formattedContent = mockDiaryContent.content.replace(
-    /([.!?])\s*/g,
-    '$1\n',
-  );
+  const {entryDate, content, imageUrl} = route.params;
+  const formattedContent = content.replace(/([.!?])\s*/g, '$1\n');
 
   const captureDiaryContent = async () => {
     try {
@@ -101,9 +97,9 @@ function DiaryContentScreen() {
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerTitle: `${formatDateToYYMMDD(createdAt)}`,
+      headerTitle: `${formatDateToYYMMDD(entryDate)}`,
     });
-  }, [navigation, createdAt]);
+  }, [navigation, entryDate]);
 
   return (
     <ScreenLayout>
@@ -111,14 +107,12 @@ function DiaryContentScreen() {
         <View collapsable={false} ref={contentRef}>
           <View style={diaryContentScreenStyle.imageContainer}>
             <Image
-              source={{uri: mockDiaryContent.imageUrl}}
+              source={{uri: imageUrl}}
               style={diaryContentScreenStyle.image}
             />
           </View>
           <View style={diaryContentScreenStyle.contentContainer}>
-            <Typography type={'headline-20'}>
-              {mockDiaryContent.title}
-            </Typography>
+            <Typography type={'headline-20'}>{content}</Typography>
             <Typography type={'body-12'}>{formattedContent}</Typography>
           </View>
         </View>

--- a/apps/app/src/screens/BottomTab/PastDiary/PastDiaryScreen.tsx
+++ b/apps/app/src/screens/BottomTab/PastDiary/PastDiaryScreen.tsx
@@ -42,6 +42,7 @@ function PastDiaryScreen() {
         id,
         entryDate,
         content,
+        imageUrl,
         isPast: true,
       });
     };

--- a/apps/app/src/screens/BottomTab/PastDiary/PastDiaryScreen.tsx
+++ b/apps/app/src/screens/BottomTab/PastDiary/PastDiaryScreen.tsx
@@ -1,28 +1,47 @@
 import {FlatList, StyleSheet} from 'react-native';
 import ScreenLayout from '../../../components/@common/ScreenLayout';
 import {formatDateToYYMMDD} from '../../../utils/formatDate';
-import {PastDiaryImageResponseDto} from '../../../types/dtos/responseDtos/PastDiary';
-import {mockPastDiaryImageList} from '../../../constants/mockDatas/pastDiaryImageList';
 import PastDiaryImageCard from '../../../components/BottomTab/PastDiary/PastDiaryImageCard';
 import useNavigator from '../../../hooks/useNavigator';
 import EmptyDiary from '../../../components/BottomTab/PastDiary/EmptyDiary';
+import {useCallback, useState} from 'react';
+import DiaryApi from '../../../apis/diary';
+import {LastDiariesResponse, LastDiary} from '../../../apis/diary/index.types';
+import {useFocusEffect} from '@react-navigation/native';
 
 function PastDiaryScreen() {
+  const [lastDiaries, setLastDiaries] = useState<LastDiariesResponse>([]);
   const {pastDiaryStackNavigation} = useNavigator();
   const pastDiaryContentContainerStyle =
-    mockPastDiaryImageList.length === 0 ? {flex: 1} : {paddingBottom: 10};
+    lastDiaries.length === 0 ? {flex: 1} : {paddingBottom: 10};
+
+  useFocusEffect(
+    useCallback(() => {
+      const getLastDiaries = async () => {
+        try {
+          const {data: lastDiariesData} = await DiaryApi.getLastDiaries();
+          setLastDiaries(lastDiariesData);
+        } catch (error) {
+          console.error('Failed to fetch diaries:', error);
+        }
+      };
+
+      getLastDiaries();
+    }, []),
+  );
 
   const renderItem = ({
-    item: {createdAt, id, imageUrl},
+    item: {entryDate, id, imageUrl, content},
   }: {
-    item: PastDiaryImageResponseDto;
+    item: LastDiary;
   }) => {
-    const formattedDate = formatDateToYYMMDD(createdAt);
+    const formattedDate = formatDateToYYMMDD(entryDate);
 
     const handlePressPastDiaryScreen = () => {
       pastDiaryStackNavigation.navigate('DiaryContent', {
         id,
-        createdAt,
+        entryDate,
+        content,
         isPast: true,
       });
     };
@@ -41,7 +60,7 @@ function PastDiaryScreen() {
       <FlatList
         style={pastDiaryScreenStyle.imageCardListContainer}
         contentContainerStyle={pastDiaryContentContainerStyle}
-        data={mockPastDiaryImageList}
+        data={lastDiaries}
         keyExtractor={item => item.id.toString()}
         renderItem={renderItem}
         numColumns={2}

--- a/apps/app/src/screens/BottomTab/PastDiary/PastDiaryScreen.tsx
+++ b/apps/app/src/screens/BottomTab/PastDiary/PastDiaryScreen.tsx
@@ -20,7 +20,11 @@ function PastDiaryScreen() {
     const formattedDate = formatDateToYYMMDD(createdAt);
 
     const handlePressPastDiaryScreen = () => {
-      pastDiaryStackNavigation.navigate('DiaryContent', {id, createdAt});
+      pastDiaryStackNavigation.navigate('DiaryContent', {
+        id,
+        createdAt,
+        isPast: true,
+      });
     };
 
     return (

--- a/apps/app/src/types/navigators.ts
+++ b/apps/app/src/types/navigators.ts
@@ -33,7 +33,8 @@ export type PastDiaryStackNavigatorParamList = {
   PastDiary: undefined;
   DiaryContent: {
     id: number;
-    createdAt: string;
+    entryDate: string;
+    content: string;
     isPast: boolean;
   };
 };

--- a/apps/app/src/types/navigators.ts
+++ b/apps/app/src/types/navigators.ts
@@ -35,6 +35,7 @@ export type PastDiaryStackNavigatorParamList = {
     id: number;
     entryDate: string;
     content: string;
+    imageUrl: string;
     isPast: boolean;
   };
 };


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #195 