### PR TITLE
Feature/#197 API 요청 시 헤더에 토큰 안 담기는 문제 해결 

### DIFF
--- a/apps/app/src/components/@common/Provider/AuthProvider.tsx
+++ b/apps/app/src/components/@common/Provider/AuthProvider.tsx
@@ -1,0 +1,120 @@
+import {
+  ReactNode,
+  useState,
+  createContext,
+  useMemo,
+  useEffect,
+  useCallback,
+} from 'react';
+import useAuthStorage from '../../../hooks/useAuthStorage';
+import useAuthInterceptor from '../../../hooks/apis/useAuthInterceptor';
+
+interface Token {
+  accessToken: string | null;
+  refreshToken: string | null;
+}
+
+interface AuthStateContext {
+  accessToken: string | null;
+  refreshToken: string | null;
+  isLoggedIn: boolean;
+}
+
+interface AuthDispatchContext {
+  setAuthData: any;
+  clearAuthData: any;
+}
+
+const defaultStateContext: AuthStateContext = {
+  accessToken: null,
+  refreshToken: null,
+  isLoggedIn: false,
+};
+
+const defaultDispatchContext: AuthDispatchContext = {
+  setAuthData: () => {},
+  clearAuthData: () => {},
+};
+
+const AuthStateContext = createContext<AuthStateContext>(defaultStateContext);
+
+export const AuthDispatchContext = createContext<AuthDispatchContext>(
+  defaultDispatchContext,
+);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+function AuthProvider({children}: AuthProviderProps) {
+  const [tokenState, setTokenState] = useState<Token>({
+    accessToken: null,
+    refreshToken: null,
+  });
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const {getToken, setToken, clearToken} = useAuthStorage();
+
+  const setAuthData = useCallback(
+    async (accessToken: string, refreshToken: string) => {
+      await setToken(accessToken, refreshToken);
+      setTokenState({
+        accessToken,
+        refreshToken,
+      });
+      setIsLoggedIn(true);
+    },
+    [setToken],
+  );
+
+  const clearAuthData = useCallback(async () => {
+    await clearToken();
+    setTokenState({
+      accessToken: null,
+      refreshToken: null,
+    });
+    setIsLoggedIn(false);
+  }, [clearToken]);
+
+  const authStateContextValue = useMemo(() => {
+    return {
+      accessToken: tokenState?.accessToken,
+      refreshToken: tokenState?.refreshToken,
+      isLoggedIn,
+    };
+  }, [tokenState, isLoggedIn]);
+
+  const authDispatchContextValue = useMemo(() => {
+    return {
+      setAuthData,
+      clearAuthData,
+    };
+  }, [clearAuthData, setAuthData]);
+
+  useEffect(() => {
+    const loadAuthData = async () => {
+      try {
+        const {accessToken, refreshToken} = await getToken();
+
+        if (accessToken && refreshToken) {
+          setAuthData(accessToken, refreshToken);
+        }
+      } catch (error) {
+        console.error('토큰 로드 실패:', error);
+      }
+    };
+
+    loadAuthData();
+  }, [getToken, setAuthData]);
+
+  useAuthInterceptor(tokenState.accessToken ?? '');
+
+  return (
+    <AuthDispatchContext.Provider value={authDispatchContextValue}>
+      <AuthStateContext.Provider value={authStateContextValue}>
+        {children}
+      </AuthStateContext.Provider>
+    </AuthDispatchContext.Provider>
+  );
+}
+
+export default AuthProvider;

--- a/apps/app/src/hooks/apis/useAuth.ts
+++ b/apps/app/src/hooks/apis/useAuth.ts
@@ -1,16 +1,17 @@
 import {Alert} from 'react-native';
 import kakaoClient from '../../apis/kakaoClient';
 import MemberApi from '../../apis/member';
-import useAuthStorage from '../useAuthStorage';
 import {
   LoginRequestBody,
   LoginResponseDto,
 } from '../../apis/member/index.types';
+import {useContext} from 'react';
+import {AuthDispatchContext} from '../../components/@common/Provider/AuthProvider';
 
 type OnSuccessCallback = (...args: any) => void;
 
 function useAuth() {
-  const {setAuthData} = useAuthStorage();
+  const {setAuthData} = useContext(AuthDispatchContext);
 
   const loginWithKakao = async (onSuccess: OnSuccessCallback) => {
     try {
@@ -32,7 +33,7 @@ function useAuth() {
 
       if (response.status === 200) {
         const {accessToken, refreshToken} = response.data;
-        setAuthData(accessToken, refreshToken);
+        await setAuthData(accessToken, refreshToken);
         onSuccess();
         return;
       }

--- a/apps/app/src/hooks/apis/useAuth.ts
+++ b/apps/app/src/hooks/apis/useAuth.ts
@@ -11,7 +11,7 @@ import {AuthDispatchContext} from '../../components/@common/Provider/AuthProvide
 type OnSuccessCallback = (...args: any) => void;
 
 function useAuth() {
-  const {setAuthData} = useContext(AuthDispatchContext);
+  const {setAuthData, clearAuthData} = useContext(AuthDispatchContext);
 
   const loginWithKakao = async (onSuccess: OnSuccessCallback) => {
     try {
@@ -62,6 +62,7 @@ function useAuth() {
       const response = await MemberApi.logout();
 
       if (response.status === 200) {
+        await clearAuthData();
         onSuccess();
       }
     } catch (error) {
@@ -78,6 +79,7 @@ function useAuth() {
       const response = await MemberApi.withdraw();
 
       if (response.status === 200) {
+        await clearAuthData();
         onSuccess();
       }
     } catch (error) {

--- a/apps/app/src/hooks/apis/useAuthInterceptor.ts
+++ b/apps/app/src/hooks/apis/useAuthInterceptor.ts
@@ -1,12 +1,10 @@
 import {useEffect, useRef} from 'react';
 import {fetcherInstance} from '../../apis/fetcher';
-import useAuthStorage from '../useAuthStorage';
 
-function useAuthInterceptor() {
+function useAuthInterceptor(accessToken: string) {
   const interceptorRef = useRef<
     ((options: RequestInit) => Promise<RequestInit>) | null
   >(null);
-  const {accessToken} = useAuthStorage();
 
   useEffect(() => {
     if (interceptorRef.current) {

--- a/apps/app/src/hooks/useAuthStorage.ts
+++ b/apps/app/src/hooks/useAuthStorage.ts
@@ -1,13 +1,9 @@
 import AsyncStorageService from '../utils/AsyncStorageService';
 import {AsyncStorageKey} from '../constants/asyncStorageKey';
-import {useCallback, useEffect, useMemo, useState} from 'react';
-import {isEmptyObject} from '../utils/isEmptyObject';
+import {useCallback, useMemo} from 'react';
 
 function useAuthStorage() {
-  const [accessToken, setAccessToken] = useState<string | null>(null);
-  const [refreshToken, setRefreshToken] = useState<string | null>(null);
-
-  const setAuthData = useCallback(
+  const setToken = useCallback(
     async (newAccessToken: string, newRefreshToken: string) => {
       try {
         await AsyncStorageService.multiSet([
@@ -21,7 +17,7 @@ function useAuthStorage() {
     [],
   );
 
-  const getAuthData = useCallback(async (): Promise<
+  const getToken = useCallback(async (): Promise<
     Record<string, string | null>
   > => {
     try {
@@ -39,10 +35,6 @@ function useAuthStorage() {
   }, []);
 
   const getAccessToken = useCallback(async (): Promise<string | null> => {
-    if (accessToken !== null) {
-      return accessToken;
-    }
-
     try {
       const accessToken: string | null = await AsyncStorageService.getItem(
         AsyncStorageKey.accessToken,
@@ -52,13 +44,9 @@ function useAuthStorage() {
       console.error('액세스 토큰 가져오기 실패:', error);
       return null;
     }
-  }, [accessToken]);
+  }, []);
 
   const getRefreshToken = useCallback(async (): Promise<string | null> => {
-    if (refreshToken !== null) {
-      return refreshToken;
-    }
-
     try {
       const refreshToken: string | null = await AsyncStorageService.getItem(
         AsyncStorageKey.refreshToken,
@@ -68,61 +56,28 @@ function useAuthStorage() {
       console.error('리프레시 토큰 가져오기 실패:', error);
       return null;
     }
-  }, [refreshToken]);
+  }, []);
 
-  const clearAuthData = useCallback(async () => {
+  const clearToken = useCallback(async () => {
     try {
       await AsyncStorageService.multiSet([
         {key: AsyncStorageKey.accessToken, value: null},
         {key: AsyncStorageKey.refreshToken, value: null},
       ]);
-
-      setAccessToken(null);
-      setRefreshToken(null);
     } catch (error) {
       console.error('토큰 삭제 실패:', error);
     }
   }, []);
 
-  useEffect(() => {
-    const loadTokens = async () => {
-      try {
-        const tokens = await getAuthData();
-
-        if (!isEmptyObject(tokens)) {
-          const accessToken = tokens[AsyncStorageKey.accessToken] || null;
-          const refreshToken = tokens[AsyncStorageKey.refreshToken] || null;
-
-          setAccessToken(accessToken);
-          setRefreshToken(refreshToken);
-        }
-      } catch (error) {
-        console.error('토큰 로드 실패:', error);
-      }
-    };
-
-    loadTokens();
-  }, [getAuthData]);
-
   return useMemo(
     () => ({
-      setAuthData,
-      getAuthData,
+      setToken,
+      getToken,
       getAccessToken,
       getRefreshToken,
-      clearAuthData,
-      accessToken,
-      refreshToken,
+      clearToken,
     }),
-    [
-      accessToken,
-      clearAuthData,
-      getAccessToken,
-      getAuthData,
-      getRefreshToken,
-      refreshToken,
-      setAuthData,
-    ],
+    [clearToken, getAccessToken, getToken, getRefreshToken, setToken],
   );
 }
 


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #197 
